### PR TITLE
Remove !importants, adjust style to match other UI elements

### DIFF
--- a/assets/concrete5inline/styles.css
+++ b/assets/concrete5inline/styles.css
@@ -1,24 +1,25 @@
-.cke_button__save {
-    background: #337ab7 !important;
+.cke_toolgroup a.cke_button__save {
+    background-color: #337ab7;
+    background-image: linear-gradient(to bottom,#337ab7, #336fad);
+    text-shadow: none;
 }
 
-.cke_button__save:hover {
-    background: #286090 !important;
+.cke_toolgroup a.cke_button__save:hover {
+    background: #286090;
+    background-image: linear-gradient(to bottom, #336fad, #315f9b);
 }
 
-.cke_button__save_label {
-    display: inline !important;
-    color: #fff !important;
+.cke_button__save .cke_button__save_label, .cke_button__cancel .cke_button__cancel_label {
+    display: inline-block;
+    padding-left: 4px;
+    padding-right: 4px;
 }
 
-.cke_button__save_icon {
-    display: none !important;
+.cke_button__save .cke_button__save_label {
+    color: #fff;
+    text-shadow: none;
 }
 
-.cke_button__cancel_label {
-    display: inline !important;
-}
-
-.cke_button__cancel_icon {
-    display: none !important;
+.cke_button__save .cke_button__save_icon, .cke_button__cancel .cke_button__cancel_icon {
+    display: none;
 }


### PR DESCRIPTION
Just some gentle changes to the css, to increase specificity, remove the text shadow from the save button, give it a gradient similar to the other buttons and adjust spacing to match.

![screen shot 2015-10-23 at 9 11 40 am](https://cloud.githubusercontent.com/assets/1079600/10680322/2dc2399c-7966-11e5-9734-215ef02d2dbf.png)
