### PR TITLE
add clearfix and min-height to editing area

### DIFF
--- a/assets/concrete5inline/styles.css
+++ b/assets/concrete5inline/styles.css
@@ -23,3 +23,17 @@
 .cke_button__save .cke_button__save_icon, .cke_button__cancel .cke_button__cancel_icon {
     display: none;
 }
+
+.cke_editable {
+    min-height: 300px;
+}
+
+.cke_editable:before,
+.cke_editable:after {
+   content: "";
+   display: table;
+}
+
+.cke_editable:after {
+    clear: both;
+}


### PR DESCRIPTION
- Floated images are removed from the document flow and are not contained by the editing area. Clearfix corrects this.
- The min-height is increased to what Redactor uses. This offers more room to edit when adding the block to a page.
