### PR TITLE
delay z-index by setTimeout

### DIFF
--- a/assets/concrete5filemanager/plugin.js
+++ b/assets/concrete5filemanager/plugin.js
@@ -53,10 +53,14 @@
                                 }
                             });
                         });
-                        setTimeout(function(){
+                         var checkVisibleDialog = setInterval(function(){
                             var topDialog = $.fn.dialog.getTop();
-                            topDialog.closest('.ui-dialog').zIndex(10012);
-                        }, 250);
+                            //console.log(topDialog.closest('.ui-dialog').length);
+                            if(topDialog.closest('.ui-dialog').length > 0){
+                                topDialog.closest('.ui-dialog').zIndex(10012);
+                                clearInterval(checkVisibleDialog);
+                            }
+                        }, 100);
                     };
                 }
 


### PR DESCRIPTION
I couldn't set image from file manager.
It might be due to the timing to add z-index status.
Change setTimeout() to setInterval.
※mac os x 10.11, chrome  51.0.2704.103 , firefox 47.0

![screenshot_at_my_environment](https://cloud.githubusercontent.com/assets/12667327/16654901/dbd900b8-4492-11e6-90ff-01a59e724153.png)
